### PR TITLE
Jules - Factory Boy 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,4 +287,50 @@ pre-commit clean
 If you would like to make a commit and skip the hooks (not recommended), use the
 `--no-verify` flag with your `git commit` command.
 
+## Testing with Factories
+
+This project uses [`factory_boy`](https://factoryboy.readthedocs.io/) to simplify the creation of test data and objects. Factories are defined in `smart_control/utils/factory_utils.py`.
+
+### Using Factories
+
+To use a factory, import it and then call it like a function. You can override default values by passing arguments:
+
+```python
+from smart_control.utils import factory_utils
+from smart_control.proto import smart_control_building_pb2 # For type hinting or specific enums
+from smart_control.utils import conversion_utils # For specific timestamp conversions if needed
+import pandas as pd
+
+# Example: Creating an ActionRequest
+sar1 = factory_utils.SingleActionRequestFactory(device_id="my_device", continuous_value=50.0)
+action_request = factory_utils.ActionRequestFactory(
+    timestamp=conversion_utils.pandas_to_proto_timestamp(pd.Timestamp("2024-07-15 10:00:00")),
+    single_action_requests=[sar1]
+)
+
+# Example: Creating a SimpleBuilding with custom start time
+custom_start = pd.Timestamp("2023-01-01", tz="UTC")
+building_instance = factory_utils.SimpleBuildingFactory(start_time=custom_start)
+```
+
+### Creating New Factories
+
+1.  **Define the Factory**: Add a new class in `smart_control/utils/factory_utils.py` inheriting from `factory.Factory`.
+2.  **Specify the Model**: In the `Meta` class, set `model` to the class or protobuf message you're creating.
+    ```python
+    class MyObjectFactory(factory.Factory):
+        class Meta:
+            model = MyActualClass # or path.to.MyProtoMessage
+    ```
+3.  **Define Attributes**:
+    *   For simple values, assign them directly: `my_field = "default_value"`
+    *   For dynamic values, use `factory.LazyFunction(lambda: some_function())` or `factory.Sequence(lambda n: f"item_{n}")`.
+    *   For Faker data, use `factory.Faker('provider_name')`.
+    *   For sub-factories (nested objects), use `factory.SubFactory(OtherFactory)`.
+    *   For lists of sub-factories, use `factory.List([factory.SubFactory(OtherFactory) for _ in range(2)])` or pass them in during instantiation with a `factory.List([])` field and a `@factory.post_generation` hook if the list items need to be appended to a protobuf repeated field.
+
+Refer to the `factory_boy` documentation for more advanced features like `post_generation` hooks, `Trait`s, etc.
+The existing factories in `smart_control/utils/factory_utils.py` provide practical examples within this codebase.
+For protobuf repeated fields that take a list of messages, define the field as `factory.List([])` and use a `@factory.post_generation` hook to extend the protobuf field with the items passed to the factory. Example: `ActionRequestFactory` for `single_action_requests`.
+
 ## [License](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ isort = "^6.0.1"
 pylint = "^3.3.6"
 pylint-per-file-ignores = "^1.4.0"
 mdformat = "^0.7.22"
+factory_boy = "^3.2.0"
 
 [tool.pyink]
 line-length = 80

--- a/smart_control/environment/environment_test.py
+++ b/smart_control/environment/environment_test.py
@@ -29,6 +29,7 @@ from tf_agents.trajectories import time_step as ts
 
 from smart_control.environment import environment
 from smart_control.environment import environment_test_utils
+from smart_control.utils import factory_utils # Added import
 from smart_control.models import base_building
 from smart_control.models import base_reward_function
 from smart_control.proto import smart_control_building_pb2
@@ -187,7 +188,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertCountEqual(expected_field_ids, output_field_ids)
 
   def test_init(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -201,7 +202,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(env.reward_function, reward_function)
 
   def test_init_default(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -232,7 +233,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
       ("1_param", [("boiler_1", "setpoint_1")], ["boiler_1_setpoint_1"]),
   )
   def test_init_device_action_tuples(self, device_action_tuples, action_names):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -255,7 +256,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertListEqual(action_names, env._action_names)
 
   def test_init_raises_value_error(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -269,7 +270,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
       )
 
   def test_init_steps_per_episode(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -280,7 +281,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(864.0, env.steps_per_episode)
 
   def test_init_action_spec(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -310,7 +311,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
       ),
   )
   def test_init_observation_spec(self, observation_histogram_reducer, expected):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -326,38 +327,42 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(env.observation_spec(), expected)
 
   def test_create_action_request(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
     env = environment.Environment(
         building, reward_function, obs_normalizer, action_config
     )
-    env.reset()
+    env.reset() # Populates _id_map, _action_names
 
     action = [1.0, -0.25, -0.456, 0.001, 0.12, -0.3]
-
-    timestamp = conversion_utils.pandas_to_proto_timestamp(
-        pd.Timestamp("2021-06-07 12:00:01")
-    )
+    
+    # Ensure simulation time is deterministic for timestamp comparison
+    timestamp_pd = pd.Timestamp("2021-06-07 12:00:01", tz="UTC") # Original test didn't specify tz, but SimpleBuilding uses UTC
+    env._simulation_time = timestamp_pd
+    proto_timestamp = conversion_utils.pandas_to_proto_timestamp(timestamp_pd)
 
     actual_request = env._create_action_request(action)
-    expected_request = smart_control_building_pb2.ActionRequest(
-        timestamp=timestamp
-    )
-    # for field_id in env._action_names:
+
+    expected_single_requests = []
     for i in range(len(env._action_names)):
       field_id = env._action_names[i]
       device, setpoint = env._id_map.inv[field_id]
-      action_normalizer = action_config.action_normalizers[setpoint]
-      normalized_value = action_normalizer.setpoint_value(action[i])
-      expected_request.single_action_requests.append(
-          smart_control_building_pb2.SingleActionRequest(
+      action_normalizer_instance = action_config.action_normalizers[setpoint]
+      normalized_value = action_normalizer_instance.setpoint_value(action[i])
+      expected_single_requests.append(
+          factory_utils.SingleActionRequestFactory(
               device_id=device,
               setpoint_name=setpoint,
               continuous_value=normalized_value,
           )
       )
+    
+    expected_request = factory_utils.ActionRequestFactory(
+        timestamp=proto_timestamp,
+        single_action_requests=expected_single_requests
+    )
 
     self.assertEqual(actual_request, expected_request)
 
@@ -370,7 +375,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
       ) -> smart_control_building_pb2.ActionResponse:
         raise RuntimeError("PhysicalAssetService.WriteFieldValues")
 
-    building = RejectionBuilding()
+    building = RejectionBuilding(start_time=pd.Timestamp("2022-03-13 00:00:00", tz="UTC")) # Needs start_time
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -398,7 +403,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
         )
         return action_response
 
-    building = StatusRejectionBuilding()
+    building = StatusRejectionBuilding(start_time=pd.Timestamp("2022-03-13 00:00:00", tz="UTC")) # Needs start_time
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -414,7 +419,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(time_step.reward, -np.inf)
 
   def test_get_observation(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -494,7 +499,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertAllClose(actual_observation, expected_observation)
 
   def test_get_observation_histogram_reducer(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -609,7 +614,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
         )
         return bad_observation_response
 
-    building = BadObservationBuilding()
+    building = BadObservationBuilding(start_time=pd.Timestamp("2022-03-13 00:00:00", tz="UTC")) # Needs start_time
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -621,7 +626,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
       env.reset()
 
   def test_compute_reward(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -638,7 +643,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     )
 
   def test_reset(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -653,7 +658,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self._assert_time_step(actual_time_step, expected_time_step)
 
   def test_action_spec(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -663,7 +668,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(env._action_spec, env.action_spec())
 
   def test_observation_spec(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -673,7 +678,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(env._observation_spec, env.observation_spec())
 
   def test_step(self):
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()
@@ -753,7 +758,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
           return time_step
         return ts.termination(env._get_observation(), reward=0.0)
 
-    building = environment_test_utils.SimpleBuilding()
+    building = factory_utils.SimpleBuildingFactory()
     reward_function = environment_test_utils.SimpleRewardFunction()
     action_config = self._create_bounded_action_config(200, 300)
     obs_normalizer = self._create_observation_normalizer()

--- a/smart_control/reward/base_setpoint_energy_carbon_reward_test.py
+++ b/smart_control/reward/base_setpoint_energy_carbon_reward_test.py
@@ -23,6 +23,7 @@ from smart_control.models.base_energy_cost import BaseEnergyCost
 from smart_control.proto import smart_control_reward_pb2
 from smart_control.reward import base_setpoint_energy_carbon_reward
 from smart_control.utils import conversion_utils
+from smart_control.utils import factory_utils # Added import
 
 
 class BaseSetpointEnergyCarbonRewardTest(parameterized.TestCase):
@@ -101,50 +102,48 @@ class BaseSetpointEnergyCarbonRewardTest(parameterized.TestCase):
       natural_gas_heating_energy_rate=5000.0,
       pump_electrical_energy_rate=250.0,
   ):
-    heating_setpoint_temperature = 293.0
-    cooling_setpoint_temperature = 297.0
-    zone_air_flow_rate_setpoint = 0.013
-    zone_air_flow_rate = 0.012
-    info = smart_control_reward_pb2.RewardInfo()
-    info.agent_id = 'test_agent'
-    info.scenario_id = 'test_scenario'
-    info.start_timestamp.CopyFrom(
-        conversion_utils.pandas_to_proto_timestamp(
-            pd.Timestamp('2021-05-03 12:13:00-5')
-        )
-    )
-    info.end_timestamp.CopyFrom(
-        conversion_utils.pandas_to_proto_timestamp(
-            pd.Timestamp('2021-05-03 12:18:00-5')
-        )
-    )
-    zone_info = smart_control_reward_pb2.RewardInfo.ZoneRewardInfo()
-    zone_info.heating_setpoint_temperature = heating_setpoint_temperature
-    zone_info.cooling_setpoint_temperature = cooling_setpoint_temperature
-    zone_info.zone_air_temperature = zone_air_temperature
-    zone_info.average_occupancy = average_occupancy
-    zone_info.air_flow_rate_setpoint = zone_air_flow_rate_setpoint
-    zone_info.air_flow_rate = zone_air_flow_rate
-    info.zone_reward_infos['0,0'].CopyFrom(zone_info)
-    info.zone_reward_infos['1,1'].CopyFrom(zone_info)
+    # Default values from original function signature that match ZoneRewardInfoFactory defaults:
+    # heating_setpoint_temperature = 293.0
+    # cooling_setpoint_temperature = 297.0
+    # zone_air_flow_rate_setpoint = 0.013
+    # zone_air_flow_rate = 0.012
 
-    air_handler_info = (
-        smart_control_reward_pb2.RewardInfo.AirHandlerRewardInfo()
-    )
-    air_handler_info.blower_electrical_energy_rate = (
-        blower_electrical_energy_rate
-    )
-    air_handler_info.air_conditioning_electrical_energy_rate = (
-        air_conditioning_electrical_energy_rate
-    )
-    info.air_handler_reward_infos['air_handler_0'].CopyFrom(air_handler_info)
+    # These will be passed to the factory if they differ from factory defaults,
+    # or used to construct the ZoneRewardInfoFactory instances.
+    zone_info_params = {
+        'zone_air_temperature': zone_air_temperature,
+        'average_occupancy': average_occupancy,
+        # heating_setpoint_temperature, cooling_setpoint_temperature, etc.
+        # will use factory defaults unless specified here.
+    }
 
-    boiler_info = smart_control_reward_pb2.RewardInfo.BoilerRewardInfo()
-    boiler_info.natural_gas_heating_energy_rate = (
-        natural_gas_heating_energy_rate
+    air_handler_info_params = {
+        'blower_electrical_energy_rate': blower_electrical_energy_rate,
+        'air_conditioning_electrical_energy_rate': air_conditioning_electrical_energy_rate,
+    }
+
+    boiler_info_params = {
+        'natural_gas_heating_energy_rate': natural_gas_heating_energy_rate,
+        'pump_electrical_energy_rate': pump_electrical_energy_rate,
+    }
+
+    # Create RewardInfo using the main factory
+    # The post_generation hooks will populate the map fields.
+    info = factory_utils.RewardInfoFactory(
+        # agent_id and scenario_id will use factory sequence defaults
+        # start_timestamp and end_timestamp will use factory defaults
+        # (factory defaults were set to match original '2021-05-03 12:13:00-5' and '12:18:00-5')
+        add_zone_infos={
+            '0,0': factory_utils.ZoneRewardInfoFactory(**zone_info_params),
+            '1,1': factory_utils.ZoneRewardInfoFactory(**zone_info_params) # Using same params for both zones as in original
+        },
+        add_air_handler_infos={
+            'air_handler_0': factory_utils.AirHandlerRewardInfoFactory(**air_handler_info_params)
+        },
+        add_boiler_infos={
+            'boiler_0': factory_utils.BoilerRewardInfoFactory(**boiler_info_params)
+        }
     )
-    boiler_info.pump_electrical_energy_rate = pump_electrical_energy_rate
-    info.boiler_reward_infos['boiler_0'].CopyFrom(boiler_info)
     return info
 
 

--- a/smart_control/reward/setpoint_energy_carbon_regret_test.py
+++ b/smart_control/reward/setpoint_energy_carbon_regret_test.py
@@ -23,6 +23,7 @@ from smart_control.models.base_energy_cost import BaseEnergyCost
 from smart_control.proto import smart_control_reward_pb2
 from smart_control.reward import setpoint_energy_carbon_regret
 from smart_control.utils import conversion_utils
+from smart_control.utils import factory_utils # Added import
 
 
 class SetpointEnergyCarbonRegretTest(parameterized.TestCase):
@@ -249,50 +250,39 @@ class SetpointEnergyCarbonRegretTest(parameterized.TestCase):
       natural_gas_heating_energy_rate=5000.0,
       pump_electrical_energy_rate=250.0,
   ):
-    heating_setpoint_temperature = 293.0
-    cooling_setpoint_temperature = 297.0
-    zone_air_flow_rate_setpoint = 0.013
-    zone_air_flow_rate = 0.012
-    info = smart_control_reward_pb2.RewardInfo()
-    info.agent_id = 'test_agent'
-    info.scenario_id = 'test_scenario'
-    info.start_timestamp.CopyFrom(
-        conversion_utils.pandas_to_proto_timestamp(
-            pd.Timestamp('2021-05-03 12:13:00-5')
-        )
-    )
-    info.end_timestamp.CopyFrom(
-        conversion_utils.pandas_to_proto_timestamp(
-            pd.Timestamp('2021-05-03 12:18:00-5')
-        )
-    )
-    zone_info = smart_control_reward_pb2.RewardInfo.ZoneRewardInfo()
-    zone_info.heating_setpoint_temperature = heating_setpoint_temperature
-    zone_info.cooling_setpoint_temperature = cooling_setpoint_temperature
-    zone_info.zone_air_temperature = zone_air_temperature
-    zone_info.average_occupancy = average_occupancy
-    zone_info.air_flow_rate_setpoint = zone_air_flow_rate_setpoint
-    zone_info.air_flow_rate = zone_air_flow_rate
-    info.zone_reward_infos['0,0'].CopyFrom(zone_info)
-    info.zone_reward_infos['1,1'].CopyFrom(zone_info)
+    # Default values from original function signature that match ZoneRewardInfoFactory defaults:
+    # heating_setpoint_temperature = 293.0
+    # cooling_setpoint_temperature = 297.0
+    # zone_air_flow_rate_setpoint = 0.013
+    # zone_air_flow_rate = 0.012
 
-    air_handler_info = (
-        smart_control_reward_pb2.RewardInfo.AirHandlerRewardInfo()
-    )
-    air_handler_info.blower_electrical_energy_rate = (
-        blower_electrical_energy_rate
-    )
-    air_handler_info.air_conditioning_electrical_energy_rate = (
-        air_conditioning_electrical_energy_rate
-    )
-    info.air_handler_reward_infos['air_handler_0'].CopyFrom(air_handler_info)
-    boiler_info = smart_control_reward_pb2.RewardInfo.BoilerRewardInfo()
-    boiler_info.natural_gas_heating_energy_rate = (
-        natural_gas_heating_energy_rate
-    )
-    boiler_info.pump_electrical_energy_rate = pump_electrical_energy_rate
-    info.boiler_reward_infos['boiler_0'].CopyFrom(boiler_info)
+    zone_info_params = {
+        'zone_air_temperature': zone_air_temperature,
+        'average_occupancy': average_occupancy,
+    }
 
+    air_handler_info_params = {
+        'blower_electrical_energy_rate': blower_electrical_energy_rate,
+        'air_conditioning_electrical_energy_rate': air_conditioning_electrical_energy_rate,
+    }
+
+    boiler_info_params = {
+        'natural_gas_heating_energy_rate': natural_gas_heating_energy_rate,
+        'pump_electrical_energy_rate': pump_electrical_energy_rate,
+    }
+
+    info = factory_utils.RewardInfoFactory(
+        add_zone_infos={
+            '0,0': factory_utils.ZoneRewardInfoFactory(**zone_info_params),
+            '1,1': factory_utils.ZoneRewardInfoFactory(**zone_info_params)
+        },
+        add_air_handler_infos={
+            'air_handler_0': factory_utils.AirHandlerRewardInfoFactory(**air_handler_info_params)
+        },
+        add_boiler_infos={
+            'boiler_0': factory_utils.BoilerRewardInfoFactory(**boiler_info_params)
+        }
+    )
     return info
 
 

--- a/smart_control/simulator/building_test.py
+++ b/smart_control/simulator/building_test.py
@@ -25,6 +25,7 @@ from smart_control.simulator import building
 from smart_control.simulator import building_utils
 from smart_control.simulator import constants
 from smart_control.simulator import stochastic_convection_simulator
+from smart_control.utils import factory_utils
 
 
 def _create_dummy_floor_plan():
@@ -604,12 +605,15 @@ class BuildingTest(parameterized.TestCase):
     np.testing.assert_array_equal(outcome, expected_output)
 
   def test_init_direct_attributes(self):
+    # Values used by _create_dummy_building_deprecated_2 and now passed to factory
     cv_size_cm = 20.0
     floor_height_cm = 300.0
     room_shape = (20, 10)
     building_shape = (6, 3)
 
-    b = _create_dummy_building_deprecated_2()
+    b = factory_utils.DeprecatedBuildingFactory(
+        room_shape=room_shape, building_shape=building_shape
+    )
 
     self.assertEqual(b.cv_size_cm, cv_size_cm)
     self.assertEqual(b.floor_height_cm, floor_height_cm)
@@ -931,9 +935,14 @@ class BuildingTest(parameterized.TestCase):
   # Below is post-refactor of direct attributes (excluding thermal diffusers):
 
   def test_init_direct_attributes_post_refactor(self):
+    # Factory default values
     cv_size_cm = 20.0
     floor_height_cm = 300.0
-    b = _create_dummy_building_post_refactor()
+    
+    dummy_floor_plan = _create_dummy_floor_plan()
+    b = factory_utils.FloorPlanBasedBuildingFactory(
+        floor_plan=dummy_floor_plan, zone_map=dummy_floor_plan
+    )
 
     with self.subTest("air"):
       self.assertEqual(b.cv_size_cm, cv_size_cm)

--- a/smart_control/simulator/simulator_building_test_lib.py
+++ b/smart_control/simulator/simulator_building_test_lib.py
@@ -19,6 +19,7 @@ from absl.testing import parameterized
 import pandas as pd
 
 from smart_control.proto import smart_control_building_pb2
+from smart_control.utils import factory_utils # Added import
 from smart_control.simulator import air_handler as air_handler_py
 from smart_control.simulator import boiler as boiler_py
 from smart_control.simulator import building as building_py
@@ -51,29 +52,29 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     Args:
       initial_temp: Initial temperature of all CVs in building.
     """
-    cv_size_cm = 20.0
-    floor_height_cm = 300.0
-    room_shape = (8, 6)
-    building_shape = (2, 1)
-    inside_air_properties = building_py.MaterialProperties(
-        conductivity=50.0, heat_capacity=700.0, density=1.0
-    )
-    inside_wall_properties = building_py.MaterialProperties(
-        conductivity=2.0, heat_capacity=500.0, density=1800.0
-    )
-    building_exterior_properties = building_py.MaterialProperties(
-        conductivity=0.05, heat_capacity=500.0, density=3000.0
-    )
+    # Original parameters for reference:
+    # cv_size_cm = 20.0
+    # floor_height_cm = 300.0
+    # room_shape = (8, 6)
+    # building_shape = (2, 1)
+    # inside_air_properties values: conductivity=50.0, heat_capacity=700.0, density=1.0
+    # inside_wall_properties values: conductivity=2.0, heat_capacity=500.0, density=1800.0
+    # building_exterior_properties values: conductivity=0.05, heat_capacity=500.0, density=3000.0
 
-    building = building_py.Building(
-        cv_size_cm,
-        floor_height_cm,
-        room_shape,
-        building_shape,
-        initial_temp,
-        inside_air_properties,
-        inside_wall_properties,
-        building_exterior_properties,
+    building = factory_utils.DeprecatedBuildingFactory(
+        initial_temp=initial_temp,
+        room_shape=(8, 6),
+        building_shape=(2, 1),
+        inside_air_properties=factory_utils.MaterialPropertiesFactory(
+            conductivity=50.0, heat_capacity=700.0, density=1.0
+        ),
+        inside_wall_properties=factory_utils.MaterialPropertiesFactory(
+            conductivity=2.0, heat_capacity=500.0, density=1800.0
+        ),
+        building_exterior_properties=factory_utils.MaterialPropertiesFactory(
+            conductivity=0.05, heat_capacity=500.0, density=3000.0
+        )
+        # cv_size_cm and floor_height_cm match factory defaults
     )
     return building
 
@@ -177,12 +178,12 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests request observations."""
     simulator_building = self.get_sim_building()
 
-    observation_request = smart_control_building_pb2.ObservationRequest()
-    single_field_request = smart_control_building_pb2.SingleObservationRequest(
+    single_field_request = factory_utils.SingleObservationRequestFactory(
         device_id='boiler_id', measurement_name=measurement_name
     )
-
-    observation_request.single_observation_requests.append(single_field_request)
+    observation_request = factory_utils.ObservationRequestFactory(
+        single_observation_requests=[single_field_request]
+    )
 
     observation_response = simulator_building.request_observations(
         observation_request
@@ -207,24 +208,14 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests request multiple observations."""
     simulator_building = self.get_sim_building()
 
-    observation_request = smart_control_building_pb2.ObservationRequest()
-
-    single_field_request_1 = (
-        smart_control_building_pb2.SingleObservationRequest(
-            device_id='boiler_id', measurement_name='supply_water_setpoint'
-        )
+    single_field_request_1 = factory_utils.SingleObservationRequestFactory(
+        device_id='boiler_id', measurement_name='supply_water_setpoint'
     )
-    observation_request.single_observation_requests.append(
-        single_field_request_1
+    single_field_request_2 = factory_utils.SingleObservationRequestFactory(
+        device_id='boiler_id', measurement_name='heating_request_count'
     )
-
-    single_field_request_2 = (
-        smart_control_building_pb2.SingleObservationRequest(
-            device_id='boiler_id', measurement_name='heating_request_count'
-        )
-    )
-    observation_request.single_observation_requests.append(
-        single_field_request_2
+    observation_request = factory_utils.ObservationRequestFactory(
+        single_observation_requests=[single_field_request_1, single_field_request_2]
     )
 
     observation_response = simulator_building.request_observations(
@@ -258,12 +249,12 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests when an observation is requested on a nonexistent device."""
     simulator_building = self.get_sim_building()
 
-    observation_request = smart_control_building_pb2.ObservationRequest()
-    single_field_request = smart_control_building_pb2.SingleObservationRequest(
+    single_field_request = factory_utils.SingleObservationRequestFactory(
         device_id='wrong_device', measurement_name='measurement_name'
     )
-
-    observation_request.single_observation_requests.append(single_field_request)
+    observation_request = factory_utils.ObservationRequestFactory(
+        single_observation_requests=[single_field_request]
+    )
 
     observation_response = simulator_building.request_observations(
         observation_request
@@ -277,12 +268,12 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests when an observation is requested for a nonexistnt measurement."""
     simulator_building = self.get_sim_building()
 
-    observation_request = smart_control_building_pb2.ObservationRequest()
-    single_field_request = smart_control_building_pb2.SingleObservationRequest(
+    single_field_request = factory_utils.SingleObservationRequestFactory(
         device_id='boiler_id', measurement_name='incorrect_measurement'
     )
-
-    observation_request.single_observation_requests.append(single_field_request)
+    observation_request = factory_utils.ObservationRequestFactory(
+        single_observation_requests=[single_field_request]
+    )
 
     observation_response = simulator_building.request_observations(
         observation_request
@@ -299,14 +290,14 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests request single action with success."""
     simulator_building = self.get_sim_building()
 
-    action_request = smart_control_building_pb2.ActionRequest()
-    single_field_request = smart_control_building_pb2.SingleActionRequest(
+    single_field_request = factory_utils.SingleActionRequestFactory(
         device_id='boiler_id',
         setpoint_name=setpoint_name,
-        continuous_value=set_value,
+        continuous_value=set_value
     )
-
-    action_request.single_action_requests.append(single_field_request)
+    action_request = factory_utils.ActionRequestFactory(
+        single_action_requests=[single_field_request]
+    )
 
     action_response = simulator_building.request_action(action_request)
 
@@ -324,12 +315,12 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests when an action is sent to a nonexistent device."""
     simulator_building = self.get_sim_building()
 
-    action_request = smart_control_building_pb2.ActionRequest()
-    single_field_request = smart_control_building_pb2.SingleActionRequest(
+    single_field_request = factory_utils.SingleActionRequestFactory(
         device_id='wrong_device', setpoint_name='setpoint_name'
     )
-
-    action_request.single_action_requests.append(single_field_request)
+    action_request = factory_utils.ActionRequestFactory(
+        single_action_requests=[single_field_request]
+    )
 
     action_response = simulator_building.request_action(action_request)
 
@@ -342,12 +333,12 @@ class SimulatorBuildingTestBase(parameterized.TestCase):
     """Tests when an action is sent to a nonexistent setpoint."""
     simulator_building = self.get_sim_building()
 
-    action_request = smart_control_building_pb2.ActionRequest()
-    single_field_request = smart_control_building_pb2.SingleActionRequest(
+    single_field_request = factory_utils.SingleActionRequestFactory(
         device_id='boiler_id', setpoint_name='incorrect_setpoint'
     )
-
-    action_request.single_action_requests.append(single_field_request)
+    action_request = factory_utils.ActionRequestFactory(
+        single_action_requests=[single_field_request]
+    )
 
     action_response = simulator_building.request_action(action_request)
 

--- a/smart_control/simulator/tf_simulator_test.py
+++ b/smart_control/simulator/tf_simulator_test.py
@@ -24,8 +24,10 @@ import tensorflow as tf
 
 from smart_control.simulator import air_handler as air_handler_py
 from smart_control.simulator import boiler as boiler_py
-from smart_control.simulator import building as building_py
+# building_py is no longer directly used for instantiation in _create_test_building
+# from smart_control.simulator import building as building_py 
 from smart_control.simulator import hvac_floorplan_based as floorplan_hvac_py
+from smart_control.utils import factory_utils # Added import
 from smart_control.simulator import setpoint_schedule
 from smart_control.simulator import tf_simulator as tf_simulator_py
 from smart_control.simulator import weather_controller as weather_controller_py
@@ -107,36 +109,22 @@ class TFSimulatorTest(absltest.TestCase):
     }
 
   def _create_test_building(self):
-    cv_size_cm = 20.0
-    floor_height_cm = 300.0
-    initial_temp = 292.0
-    inside_air_properties = building_py.MaterialProperties(
-        conductivity=50.0, heat_capacity=700.0, density=1.0
-    )
-    inside_wall_properties = building_py.MaterialProperties(
-        conductivity=2.0, heat_capacity=1000.0, density=1800.0
-    )
-    building_exterior_properties = building_py.MaterialProperties(
-        conductivity=0.05, heat_capacity=1000.0, density=3000.0
-    )
+    # cv_size_cm = 20.0 (matches factory default)
+    # floor_height_cm = 300.0 (matches factory default)
+    # initial_temp = 292.0 (matches factory default)
+
+    # Original inside_air_properties values: conductivity=50.0, heat_capacity=700.0, density=1.0 (matches factory default for inside_air_properties)
+    # Original inside_wall_properties values: conductivity=2.0, heat_capacity=1000.0, density=1800.0 (matches factory default for inside_wall_properties)
+    # Original building_exterior_properties values: conductivity=0.05, heat_capacity=1000.0, density=3000.0 (matches factory default for building_exterior_properties)
 
     floor_plan = self._create_test_floor_plan()
-    zone_map = self._create_test_floor_plan()
+    # zone_map is the same as floor_plan in the original code
 
-    b = building_py.FloorPlanBasedBuilding(
-        cv_size_cm=cv_size_cm,
-        floor_height_cm=floor_height_cm,
-        initial_temp=initial_temp,
-        inside_air_properties=inside_air_properties,
-        inside_wall_properties=inside_wall_properties,
-        building_exterior_properties=building_exterior_properties,
+    b = factory_utils.FloorPlanBasedBuildingFactory(
         floor_plan=floor_plan,
-        floor_plan_filepath=None,
-        zone_map=zone_map,
-        zone_map_filepath=None,
-        buffer_from_walls=0,
+        zone_map=floor_plan
+        # All other parameters match the factory defaults or the specific MaterialProperty sub-factory defaults.
     )
-
     return b
 
   def _create_small_hvac(self):

--- a/smart_control/utils/BUILD
+++ b/smart_control/utils/BUILD
@@ -41,6 +41,35 @@ py_library(
     ],
 )
 
+py_library(
+    name = "factory_utils",
+    srcs = ["factory_utils.py"],
+    deps = [
+        ":conversion_utils",
+        "//smart_control/environment:environment_test_utils",
+        "//smart_control/proto:smart_control_building_py_pb2",
+        "//smart_control/simulator:building",
+        "@pip//factory_boy",
+        "@pip//numpy",
+        "@pip//pandas",
+    ],
+)
+
+py_strict_test(
+    name = "factory_utils_test",
+    srcs = ["factory_utils_test.py"],
+    deps = [
+        ":conversion_utils",
+        ":factory_utils",
+        "//smart_control/environment:environment_test_utils",
+        "//smart_control/proto:smart_control_building_py_pb2",
+        "//smart_control/simulator:building",
+        "@pip//absl_py",
+        "@pip//numpy",
+        "@pip//pandas",
+    ],
+)
+
 py_strict_test(
     name = "agent_utils_test",
     srcs = ["agent_utils_test.py"],

--- a/smart_control/utils/factory_utils.py
+++ b/smart_control/utils/factory_utils.py
@@ -1,0 +1,263 @@
+import factory
+import pandas as pd # Adjusted pandas import
+import numpy as np # Added import
+from smart_control.proto import smart_control_building_pb2
+from smart_control.proto import smart_control_reward_pb2 # Added import
+from smart_control.utils import conversion_utils # For pandas_to_proto_timestamp
+from smart_control.environment import environment_test_utils
+from smart_control.simulator import building # Added for building.MaterialProperties etc.
+
+class ActionRequestFactory(factory.Factory):
+    class Meta:
+        model = smart_control_building_pb2.ActionRequest
+
+    timestamp = factory.LazyFunction(lambda: conversion_utils.pandas_to_proto_timestamp(pd.Timestamp("2023-10-26 10:00:00")))
+    
+    # single_action_requests field allows passing a list of SingleActionRequest objects when creating an ActionRequest
+    single_action_requests = factory.List([])
+
+    @factory.post_generation
+    def fill_single_action_requests(obj, create, results=None):
+        # This hook processes the 'single_action_requests' list passed during factory creation.
+        # 'results' here will be the list provided to 'single_action_requests' parameter.
+        if results:
+            obj.single_action_requests.extend(results)
+
+class SingleActionRequestFactory(factory.Factory):
+    class Meta:
+        model = smart_control_building_pb2.SingleActionRequest
+
+    device_id = factory.Sequence(lambda n: f"device_{n}")
+    setpoint_name = factory.Sequence(lambda n: f"setpoint_{n}")
+    continuous_value = factory.Faker('pyfloat', left_digits=2, right_digits=2, positive=True, min_value=10.0, max_value=30.0)
+    # discrete_value, string_value, boolean_value can be added if needed
+
+# Example of how to use it with ActionRequestFactory:
+# action_request = ActionRequestFactory(
+#     add_single_request=[
+#         SingleActionRequestFactory(device_id="boiler_1", setpoint_name="temperature", continuous_value=25.5),
+#         SingleActionRequestFactory(device_id="vav_1", setpoint_name="flow", continuous_value=100.0)
+#     ]
+# )
+# Or by building them separately:
+# sar1 = SingleActionRequestFactory()
+# action_request = ActionRequestFactory(single_action_requests=[sar1])
+
+
+class SingleObservationRequestFactory(factory.Factory):
+    class Meta:
+        model = smart_control_building_pb2.SingleObservationRequest
+
+    device_id = factory.Sequence(lambda n: f"obs_device_{n}")
+    measurement_name = factory.Sequence(lambda n: f"obs_measurement_{n}")
+
+class ObservationRequestFactory(factory.Factory):
+    class Meta:
+        model = smart_control_building_pb2.ObservationRequest
+    
+    timestamp = factory.LazyFunction(lambda: conversion_utils.pandas_to_proto_timestamp(pd.Timestamp("2023-10-26 10:00:00")))
+    single_observation_requests = factory.List([]) # Add this
+
+    @factory.post_generation # Add this hook
+    def fill_single_observation_requests(obj, create, results=None):
+        if results:
+            obj.single_observation_requests.extend(results)
+
+class SingleObservationResponseFactory(factory.Factory):
+    class Meta:
+        model = smart_control_building_pb2.SingleObservationResponse
+
+    single_observation_request = factory.SubFactory(SingleObservationRequestFactory)
+    timestamp = factory.LazyFunction(lambda: conversion_utils.pandas_to_proto_timestamp(pd.Timestamp("2023-10-26 10:00:00")))
+    observation_valid = True
+    continuous_value = factory.Faker('pyfloat', left_digits=2, right_digits=2, positive=True, min_value=60.0, max_value=80.0)
+    # discrete_value, string_value, boolean_value can be added if needed
+
+class ObservationResponseFactory(factory.Factory):
+    class Meta:
+        model = smart_control_building_pb2.ObservationResponse
+
+    timestamp = factory.LazyFunction(lambda: conversion_utils.pandas_to_proto_timestamp(pd.Timestamp("2023-10-26 10:00:00")))
+    request = factory.SubFactory(ObservationRequestFactory) # Link to ObservationRequestFactory
+    # single_observation_responses can be built using a post_generation hook or by passing a list of SingleObservationResponse instances
+    # Example:
+    # @factory.post_generation
+    # def add_single_observation_responses(obj, create, results=None):
+    #     if not create:
+    #         return
+    #     if results: # results is a list of SingleObservationResponse instances
+    #         for res in results:
+    #             obj.single_observation_responses.append(res)
+
+
+class SimpleBuildingFactory(factory.Factory):
+    class Meta:
+        model = environment_test_utils.SimpleBuilding
+
+    # SimpleBuilding constructor takes:
+    # start_time: pd.Timestamp = pd.Timestamp("2022-03-13 00:00:00", tz="UTC"),
+    # step_duration: pd.Timedelta = pd.Timedelta(minutes=10),
+    # setpoint_names: Optional[list[str]] = None,
+    # measurement_names: Optional[list[str]] = None,
+
+    start_time = pd.Timestamp("2022-03-13 00:00:00", tz="UTC")
+    step_duration = pd.Timedelta(minutes=10)
+    setpoint_names = factory.List([
+        "setpoint_1", "setpoint_2", "setpoint_3", "setpoint_4", "setpoint_5", "setpoint_6"
+    ])
+    measurement_names = factory.List([
+        "measurement_1", "measurement_2", "measurement_3", "measurement_4", "measurement_5"
+    ])
+
+    # This factory will initialize SimpleBuilding with some default values.
+    # The `values` dictionary in SimpleBuilding is initialized within its __init__
+    # based on measurement_names.
+
+
+# Factory for MaterialProperties
+class MaterialPropertiesFactory(factory.Factory):
+    class Meta:
+        model = building.MaterialProperties
+
+    conductivity = factory.Faker('pyfloat', left_digits=1, right_digits=2, positive=True, min_value=0.01, max_value=50.0)
+    heat_capacity = factory.Faker('pyfloat', left_digits=3, right_digits=1, positive=True, min_value=700.0, max_value=1200.0)
+    density = factory.Faker('pyfloat', left_digits=3, right_digits=1, positive=True, min_value=1.0, max_value=3000.0)
+
+# Factory for the deprecated building.Building
+class DeprecatedBuildingFactory(factory.Factory):
+    class Meta:
+        model = building.Building
+
+    cv_size_cm = 20.0
+    floor_height_cm = 300.0
+    room_shape = (3, 2) # Default room_shape (rows, cols) for CVs
+    building_shape = (2, 3) # Default building_shape (rooms_x, rooms_y)
+    initial_temp = 292.0
+    inside_air_properties = factory.SubFactory(MaterialPropertiesFactory, conductivity=50.0, heat_capacity=700.0, density=1.0)
+    inside_wall_properties = factory.SubFactory(MaterialPropertiesFactory, conductivity=2.0, heat_capacity=1000.0, density=1800.0)
+    building_exterior_properties = factory.SubFactory(MaterialPropertiesFactory, conductivity=0.05, heat_capacity=1000.0, density=3000.0)
+
+# Factory for building.FloorPlanBasedBuilding
+class FloorPlanBasedBuildingFactory(factory.Factory):
+    class Meta:
+        model = building.FloorPlanBasedBuilding
+
+    cv_size_cm = 20.0
+    floor_height_cm = 300.0
+    initial_temp = 292.0
+    inside_air_properties = factory.SubFactory(MaterialPropertiesFactory, conductivity=50.0, heat_capacity=700.0, density=1.0)
+    inside_wall_properties = factory.SubFactory(MaterialPropertiesFactory, conductivity=2.0, heat_capacity=1000.0, density=1800.0)
+    building_exterior_properties = factory.SubFactory(MaterialPropertiesFactory, conductivity=0.05, heat_capacity=1000.0, density=3000.0)
+    
+    floor_plan_filepath = None # Must be None if floor_plan array is provided
+    zone_map_filepath = None   # Must be None if zone_map array is provided
+    buffer_from_walls = 0
+    diffuser_spacing = 10 # A default value, can be overridden
+
+    # Default floor_plan and zone_map (simple 1-room)
+    # Users can override these with more complex np.arrays
+    floor_plan = factory.LazyFunction(lambda: np.array([
+        [2, 2, 2, 2, 2],
+        [2, 1, 0, 1, 2], # 0 is room, 1 is interior wall, 2 is exterior wall
+        [2, 1, 0, 1, 2],
+        [2, 1, 0, 1, 2],
+        [2, 2, 2, 2, 2],
+    ], dtype=np.int32))
+    
+    zone_map = factory.LazyAttribute(lambda o: o.floor_plan) # By default, zone_map is same as floor_plan
+
+    # For stochastic convection simulator, if needed by tests
+    # convection_simulator = None
+
+
+class ZoneRewardInfoFactory(factory.Factory):
+    class Meta:
+        model = smart_control_reward_pb2.RewardInfo.ZoneRewardInfo
+
+    heating_setpoint_temperature = 293.0
+    cooling_setpoint_temperature = 297.0
+    zone_air_temperature = 294.0
+    average_occupancy = 5.0
+    air_flow_rate_setpoint = 0.013
+    air_flow_rate = 0.012
+
+class AirHandlerRewardInfoFactory(factory.Factory):
+    class Meta:
+        model = smart_control_reward_pb2.RewardInfo.AirHandlerRewardInfo
+
+    blower_electrical_energy_rate = 800.0
+    air_conditioning_electrical_energy_rate = 4500.0
+    # Add other fields if they become commonly used in tests
+
+class BoilerRewardInfoFactory(factory.Factory):
+    class Meta:
+        model = smart_control_reward_pb2.RewardInfo.BoilerRewardInfo
+
+    natural_gas_heating_energy_rate = 5000.0
+    pump_electrical_energy_rate = 250.0
+    # Add other fields if they become commonly used in tests
+
+class RewardInfoFactory(factory.Factory):
+    class Meta:
+        model = smart_control_reward_pb2.RewardInfo
+
+    agent_id = factory.Sequence(lambda n: f"test_agent_{n}")
+    scenario_id = factory.Sequence(lambda n: f"test_scenario_{n}")
+    start_timestamp = factory.LazyFunction(
+        lambda: conversion_utils.pandas_to_proto_timestamp(pd.Timestamp('2021-05-03 12:13:00-05:00', tz='UTC-5')) # Keep tz for consistency
+    )
+    end_timestamp = factory.LazyFunction(
+        lambda: conversion_utils.pandas_to_proto_timestamp(pd.Timestamp('2021-05-03 12:18:00-05:00', tz='UTC-5'))
+    )
+
+    # For map fields like zone_reward_infos, air_handler_reward_infos, boiler_reward_infos
+    # it's often easier to populate them post-generation or by passing pre-constructed dicts.
+    # However, we can provide a way to generate default ones if needed.
+
+    @factory.post_generation
+    def add_zone_infos(obj, create, results=None):
+        if not create:
+            return
+        if results: # Expects a dict like {'zone_id': ZoneRewardInfoFactory_instance or dict}
+            for zone_id, zone_info_data in results.items():
+                if isinstance(zone_info_data, factory.base.StubObject): # if passed a factory instance
+                    obj.zone_reward_infos[zone_id].CopyFrom(zone_info_data)
+                elif isinstance(zone_info_data, dict): # if passed a dict of params for the factory
+                    obj.zone_reward_infos[zone_id].CopyFrom(ZoneRewardInfoFactory(**zone_info_data))
+                else: # if passed a fully constructed protobuf message
+                    obj.zone_reward_infos[zone_id].CopyFrom(zone_info_data)
+        # else:
+            # Optionally create default zone_infos
+            # obj.zone_reward_infos['0,0'].CopyFrom(ZoneRewardInfoFactory())
+            # obj.zone_reward_infos['1,1'].CopyFrom(ZoneRewardInfoFactory())
+
+
+    @factory.post_generation
+    def add_air_handler_infos(obj, create, results=None):
+        if not create:
+            return
+        if results: # Expects a dict like {'handler_id': AirHandlerRewardInfoFactory_instance or dict}
+            for handler_id, handler_info_data in results.items():
+                if isinstance(handler_info_data, factory.base.StubObject):
+                    obj.air_handler_reward_infos[handler_id].CopyFrom(handler_info_data)
+                elif isinstance(handler_info_data, dict):
+                     obj.air_handler_reward_infos[handler_id].CopyFrom(AirHandlerRewardInfoFactory(**handler_info_data))
+                else:
+                    obj.air_handler_reward_infos[handler_id].CopyFrom(handler_info_data)
+        # else:
+            # obj.air_handler_reward_infos['air_handler_0'].CopyFrom(AirHandlerRewardInfoFactory())
+
+    @factory.post_generation
+    def add_boiler_infos(obj, create, results=None):
+        if not create:
+            return
+        if results: # Expects a dict like {'boiler_id': BoilerRewardInfoFactory_instance or dict}
+            for boiler_id, boiler_info_data in results.items():
+                if isinstance(boiler_info_data, factory.base.StubObject):
+                    obj.boiler_reward_infos[boiler_id].CopyFrom(boiler_info_data)
+                elif isinstance(boiler_info_data, dict):
+                    obj.boiler_reward_infos[boiler_id].CopyFrom(BoilerRewardInfoFactory(**boiler_info_data))
+                else:
+                    obj.boiler_reward_infos[boiler_id].CopyFrom(boiler_info_data)
+        # else:
+            # obj.boiler_reward_infos['boiler_0'].CopyFrom(BoilerRewardInfoFactory())

--- a/smart_control/utils/factory_utils_test.py
+++ b/smart_control/utils/factory_utils_test.py
@@ -1,0 +1,106 @@
+from absl.testing import absltest
+from absl.testing import parameterized
+import pandas as pd
+import numpy as np
+
+from smart_control.utils import factory_utils
+from smart_control.proto import smart_control_building_pb2
+from smart_control.environment import environment_test_utils
+from smart_control.simulator import building
+from smart_control.utils import conversion_utils
+
+class FactoryUtilsTest(parameterized.TestCase):
+
+    def test_action_request_factory_variations(self):
+        # Default instance
+        default_ar = factory_utils.ActionRequestFactory()
+        self.assertIsInstance(default_ar, smart_control_building_pb2.ActionRequest)
+        self.assertEqual(len(default_ar.single_action_requests), 0)
+
+        # With a specific timestamp
+        custom_timestamp_pd = pd.Timestamp("2024-01-01 12:00:00")
+        custom_timestamp_proto = conversion_utils.pandas_to_proto_timestamp(custom_timestamp_pd)
+        ar_custom_ts = factory_utils.ActionRequestFactory(timestamp=custom_timestamp_proto)
+        self.assertEqual(ar_custom_ts.timestamp, custom_timestamp_proto)
+
+        # With multiple single action requests
+        sar1 = factory_utils.SingleActionRequestFactory(
+            device_id="boiler_complex",
+            setpoint_name="temp_set",
+            continuous_value=75.0
+        )
+        sar2 = factory_utils.SingleActionRequestFactory(
+            device_id="vav_complex",
+            setpoint_name="flow_rate",
+            continuous_value=120.5
+        )
+        ar_with_sars = factory_utils.ActionRequestFactory(
+            single_action_requests=[sar1, sar2]
+        )
+        self.assertEqual(len(ar_with_sars.single_action_requests), 2)
+        self.assertEqual(ar_with_sars.single_action_requests[0].device_id, "boiler_complex")
+        self.assertEqual(ar_with_sars.single_action_requests[1].continuous_value, 120.5)
+
+    def test_simple_building_factory_variations(self):
+        # Default instance
+        default_sb = factory_utils.SimpleBuildingFactory()
+        self.assertIsInstance(default_sb, environment_test_utils.SimpleBuilding)
+        self.assertEqual(default_sb.start_time, pd.Timestamp("2022-03-13 00:00:00", tz="UTC"))
+        self.assertIn("setpoint_1", default_sb.setpoint_names)
+
+        # With custom start_time and setpoint_names
+        custom_start_time = pd.Timestamp("2023-05-10 08:00:00", tz="America/New_York")
+        custom_setpoints = ["custom_sp_1", "custom_sp_2"]
+        sb_custom = factory_utils.SimpleBuildingFactory(
+            start_time=custom_start_time,
+            setpoint_names=custom_setpoints
+        )
+        self.assertEqual(sb_custom.start_time, custom_start_time)
+        self.assertEqual(sb_custom.setpoint_names, custom_setpoints)
+        # Check that values dict is updated based on new measurement_names (if logic is tied)
+        # or ensure measurement_names can also be customized.
+        # For SimpleBuilding, `values` are initialized with measurement_names.
+        # Let's test with custom measurement_names too.
+        custom_measurements = ["custom_m_1"]
+        sb_custom_measure = factory_utils.SimpleBuildingFactory(
+            measurement_names=custom_measurements
+        )
+        self.assertEqual(sb_custom_measure.measurement_names, custom_measurements)
+        for m_name in custom_measurements:
+            self.assertIn(m_name, sb_custom_measure.values)
+
+
+    def test_floor_plan_building_factory_variations(self):
+        # Default instance
+        default_fpb = factory_utils.FloorPlanBasedBuildingFactory()
+        self.assertIsInstance(default_fpb, building.FloorPlanBasedBuilding)
+        self.assertEqual(default_fpb.cv_size_cm, 20.0)
+
+        # With a custom floor plan
+        custom_plan = np.array([
+            [2, 2, 2, 2],
+            [2, 0, 0, 2], # A small room
+            [2, 0, 0, 2],
+            [2, 2, 2, 2],
+        ], dtype=np.int32)
+        
+        fpb_custom_plan = factory_utils.FloorPlanBasedBuildingFactory(
+            floor_plan=custom_plan,
+            zone_map=custom_plan # Assuming zone_map matches for simplicity here
+        )
+        np.testing.assert_array_equal(fpb_custom_plan.floor_plan, custom_plan)
+        self.assertEqual(fpb_custom_plan.initial_temp, 292.0) # Default initial_temp
+
+        # With custom initial temperature and properties
+        custom_temp = 300.0
+        custom_air_props = factory_utils.MaterialPropertiesFactory(conductivity=60.0)
+        fpb_custom_props = factory_utils.FloorPlanBasedBuildingFactory(
+            initial_temp=custom_temp,
+            inside_air_properties=custom_air_props
+        )
+        self.assertEqual(fpb_custom_props.initial_temp, custom_temp)
+        self.assertEqual(fpb_custom_props.inside_air_properties.conductivity, 60.0)
+
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
I refactored your tests to use factory_boy for test data generation.

I introduced factory_boy and refactored several of your test files to use factories, simplifying test data setup and improving maintainability.

Here are the key changes:
- Added `factory_boy` to your project dependencies.
- Created `smart_control/utils/factory_utils.py` with factories for:
    - Protobufs: `ActionRequest`, `ObservationRequest`, `ObservationResponse`, `RewardInfo` and their sub-components.
    - Custom classes: `SimpleBuilding`, `MaterialProperties`, `Building` (deprecated), `FloorPlanBasedBuilding`.
- Refactored tests in:
    - `smart_control/environment/environment_test.py`
    - `smart_control/simulator/building_test.py`
    - `smart_control/simulator/simulator_building_test_lib.py`
    - `smart_control/simulator/tf_simulator_test.py`
    - `smart_control/reward/base_setpoint_energy_carbon_reward_test.py`
    - `smart_control/reward/setpoint_energy_carbon_regret_test.py`
- Added `smart_control/utils/factory_utils_test.py` with usage examples.
- Updated `smart_control/utils/BUILD` for new files and dependencies.
- Documented factory usage in `README.md`.

This work is part of an ongoing effort to improve test clarity and reduce boilerplate by leveraging factories for test object creation.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR