### PR TITLE
Jules - BUILD Files

### DIFF
--- a/smart_control/reinforcement_learning/agents/BUILD
+++ b/smart_control/reinforcement_learning/agents/BUILD
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "agents",
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning:__pkg__"],
+)
+
+pytype_strict_library(
+    name = "sac_agent",
+    srcs = ["sac_agent.py"],
+    deps = [
+        "//smart_control/reinforcement_learning/agents/networks:sac_networks",
+        "//third_party/py/tensorflow",
+        "//third_party/py/tf_agents",
+    ],
+)

--- a/smart_control/reinforcement_learning/agents/networks/BUILD
+++ b/smart_control/reinforcement_learning/agents/networks/BUILD
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "networks",
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning/agents:__pkg__"],
+)
+
+pytype_strict_library(
+    name = "sac_networks",
+    srcs = ["sac_networks.py"],
+    deps = [
+        "//third_party/py/tensorflow",
+        "//third_party/py/tf_agents",
+    ],
+)

--- a/smart_control/reinforcement_learning/observers/BUILD
+++ b/smart_control/reinforcement_learning/observers/BUILD
@@ -1,0 +1,73 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "observers",
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning:__pkg__"],
+)
+
+pytype_strict_library(
+    name = "base_observer",
+    srcs = ["base_observer.py"],
+    deps = [
+        "//third_party/py/tf_agents",
+    ],
+)
+
+pytype_strict_library(
+    name = "composite_observer",
+    srcs = ["composite_observer.py"],
+    deps = [
+        ":base_observer",
+        "//third_party/py/tf_agents",
+    ],
+)
+
+pytype_strict_library(
+    name = "print_status_observer",
+    srcs = ["print_status_observer.py"],
+    deps = [
+        ":base_observer",
+        "//smart_control/reinforcement_learning/utils:constants",
+        "//third_party/py/pandas",
+        "//third_party/py/tf_agents",
+    ],
+)
+
+pytype_strict_library(
+    name = "rendering_observer",
+    srcs = ["rendering_observer.py"],
+    deps = [
+        ":base_observer",
+        "//smart_control/environment",
+        "//smart_control/reinforcement_learning/utils:config",
+        "//smart_control/reinforcement_learning/utils:constants",
+        "//smart_control/reinforcement_learning/utils:data_processing",
+        "//smart_control/utils:building_renderer",
+        "//third_party/py/matplotlib",
+        "//third_party/py/pandas",
+        "//third_party/py/pytz",
+        "//third_party/py/tf_agents",
+    ],
+)

--- a/smart_control/reinforcement_learning/policies/BUILD
+++ b/smart_control/reinforcement_learning/policies/BUILD
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "policies",
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning:__pkg__"],
+)
+
+pytype_strict_library(
+    name = "schedule_policy",
+    srcs = ["schedule_policy.py"],
+    deps = [
+        "//smart_control/reinforcement_learning/utils:constants",
+        "//smart_control/reinforcement_learning/utils:time_utils",
+        "//third_party/py/numpy",
+        "//third_party/py/pandas",
+        "//third_party/py/tensorflow",
+        "//third_party/py/tf_agents",
+    ],
+)

--- a/smart_control/reinforcement_learning/replay_buffer/BUILD
+++ b/smart_control/reinforcement_learning/replay_buffer/BUILD
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is
+# distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "replay_buffer_lib", # Changed from "replay_buffer" to avoid conflict with directory name
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning:__pkg__"],
+)
+
+pytype_strict_library(
+    name = "replay_buffer",
+    srcs = ["replay_buffer.py"],
+    deps = [
+        "//third_party/py/reverb",
+        "//third_party/py/tensorflow",
+        "//third_party/py/tf_agents",
+    ],
+)

--- a/smart_control/reinforcement_learning/scripts/BUILD
+++ b/smart_control/reinforcement_learning/scripts/BUILD
@@ -1,0 +1,77 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+load("//devtools/python/blaze:strict.bzl", "py_strict_binary")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "scripts_lib", # Renamed to avoid conflict
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning:__pkg__"],
+)
+
+# Library target for populate_starter_buffer.py
+pytype_strict_library(
+    name = "populate_starter_buffer_lib",
+    srcs = ["populate_starter_buffer.py"],
+    deps = [
+        "//smart_control/reinforcement_learning/observers:composite_observer",
+        "//smart_control/reinforcement_learning/observers:print_status_observer",
+        "//smart_control/reinforcement_learning/policies:schedule_policy",
+        "//smart_control/reinforcement_learning/replay_buffer",
+        "//smart_control/reinforcement_learning/utils:config",
+        "//smart_control/reinforcement_learning/utils:environment",
+        "//third_party/py/tensorflow",
+        "//third_party/py/tf_agents",
+    ],
+)
+
+# Binary target for populate_starter_buffer.py
+py_strict_binary(
+    name = "populate_starter_buffer",
+    srcs = ["populate_starter_buffer.py"],
+    main = "populate_starter_buffer.py", # Specifies the main entry point
+    deps = [":populate_starter_buffer_lib"],
+)
+
+# Library target for train.py
+pytype_strict_library(
+    name = "train_lib",
+    srcs = ["train.py"],
+    deps = [
+        "//smart_control/reinforcement_learning/agents:sac_agent",
+        "//smart_control/reinforcement_learning/observers:composite_observer",
+        "//smart_control/reinforcement_learning/observers:print_status_observer",
+        "//smart_control/reinforcement_learning/replay_buffer",
+        "//smart_control/reinforcement_learning/utils:config",
+        "//smart_control/reinforcement_learning/utils:environment",
+        "//third_party/py/tensorflow",
+        "//third_party/py/tf_agents",
+    ],
+)
+
+# Binary target for train.py
+py_strict_binary(
+    name = "train",
+    srcs = ["train.py"],
+    main = "train.py", # Specifies the main entry point
+    deps = [":train_lib"],
+)

--- a/smart_control/reinforcement_learning/utils/BUILD
+++ b/smart_control/reinforcement_learning/utils/BUILD
@@ -1,0 +1,119 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//devtools/python/blaze:pytype.bzl", "pytype_strict_library")
+load("//devtools/python/blaze:strict.bzl", "py_strict_test")
+
+package(
+    default_applicable_licenses = ["//third_party/py/smart_buildings:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+pytype_strict_library(
+    name = "utils",
+    srcs = ["__init__.py"],
+    visibility = ["//smart_control/reinforcement_learning:__pkg__"],
+)
+
+pytype_strict_library(
+    name = "constants",
+    srcs = ["constants.py"],
+)
+
+pytype_strict_library(
+    name = "config",
+    srcs = ["config.py"],
+    deps = [
+        "//smart_control/reward:electricity_energy_cost",
+        "//smart_control/reward:natural_gas_energy_cost",
+        "//smart_control/reward:setpoint_energy_carbon_regret",
+        "//smart_control/simulator:air_handler",
+        "//smart_control/simulator:boiler",
+        "//smart_control/simulator:building",
+        "//smart_control/simulator:hvac_floorplan_based",
+        "//smart_control/simulator:randomized_arrival_departure_occupancy",
+        "//smart_control/simulator:simulator_building",
+        "//smart_control/simulator:stochastic_convection_simulator",
+        "//smart_control/simulator:tf_simulator",
+        "//smart_control/simulator:weather_controller",
+        "//smart_control/utils:constants", # This is smart_control.utils.constants
+        "//smart_control/utils:controller_reader",
+        "//smart_control/utils:controller_writer",
+        "//smart_control/utils:environment_utils",
+        "//smart_control/utils:histogram_reducer",
+        "//smart_control/utils:observation_normalizer",
+        "//third_party/py/gin",
+        "//third_party/py/numpy",
+    ],
+)
+
+py_strict_test(
+    name = "config_test",
+    srcs = ["config_test.py"],
+    deps = [
+        "//smart_control/utils:constants", # This is smart_control.utils.constants
+        "//third_party/py/absl/testing:absltest",
+    ],
+)
+
+pytype_strict_library(
+    name = "data_processing",
+    srcs = ["data_processing.py"],
+    deps = [
+        ":constants", # Refers to sm_rl.utils.constants
+        "//smart_control/utils:controller_reader",
+        "//smart_control/utils:conversion_utils",
+        "//third_party/py/numpy",
+        "//third_party/py/pandas",
+    ],
+)
+
+py_strict_test(
+    name = "data_processing_test",
+    srcs = ["data_processing_test.py"],
+    deps = [
+        ":data_processing",
+        "//third_party/py/absl/testing:absltest",
+    ],
+)
+
+pytype_strict_library(
+    name = "environment",
+    srcs = ["environment.py"],
+    deps = [
+        ":constants", # Refers to sm_rl.utils.constants
+        "//smart_control/environment",
+        "//third_party/py/gin",
+    ],
+)
+
+pytype_strict_library(
+    name = "metrics",
+    srcs = ["metrics.py"],
+    deps = [
+        ":constants", # Refers to sm_rl.utils.constants
+        "//third_party/py/numpy",
+        "//third_party/py/tf_agents",
+    ],
+)
+
+pytype_strict_library(
+    name = "time_utils",
+    srcs = ["time_utils.py"],
+    deps = [
+        "//third_party/py/numpy",
+    ],
+)

--- a/smart_control/utils/BUILD
+++ b/smart_control/utils/BUILD
@@ -24,12 +24,12 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-py_library(
+pytype_strict_library(
     name = "constants",
     srcs = ["constants.py"],
 )
 
-py_library(
+pytype_strict_library(
     name = "conversion_utils",
     srcs = ["conversion_utils.py"],
     deps = [


### PR DESCRIPTION
Add BUILD files to reinforcement_learning module and update py_library.

This commit introduces BUILD files to all subdirectories within the smart_control/reinforcement_learning module. These BUILD files define pytype_strict_library targets for all Python files, py_strict_binary targets for executable scripts, and py_strict_test targets for test files. Dependencies for each target have been determined by analyzing their imports.

Additionally, this commit updates one existing BUILD file (smart_control/utils/BUILD) to replace py_library targets with pytype_strict_library, ensuring consistency in the use of strict Python rules.

Summary of changes:
- Updated smart_control/utils/BUILD:
    - Replaced py_library with pytype_strict_library for 'constants' and 'conversion_utils'.
    - Removed unused load statement for py_library.
- Added smart_control/reinforcement_learning/agents/BUILD
- Added smart_control/reinforcement_learning/agents/networks/BUILD
- Added smart_control/reinforcement_learning/observers/BUILD
- Added smart_control/reinforcement_learning/policies/BUILD
- Added smart_control/reinforcement_learning/replay_buffer/BUILD
- Added smart_control/reinforcement_learning/scripts/BUILD
- Added smart_control/reinforcement_learning/utils/BUILD

Fixes #79 